### PR TITLE
corrected example usage's docker image name

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Running the relay is super simple.
         -e 'TORRC=/etc/tor/torrc.middle' \
         -e 'NICKNAME=hacktheplanet' \
         --name=torrelay \
-        thezero/tor-relay
+        thezero/docker-tor-relay
 
 ### Required configuration
 
@@ -62,4 +62,4 @@ You can do this by passing on the following.
         -e 'NICKNAME=thezero' \
         -e 'CONTACTINFO=TheZero <io@thezero.org>' \
         --name=torrelay \
-        thezero/tor-relay
+        thezero/docker-tor-relay


### PR DESCRIPTION
changed thezero/tor-relay to thezero/docker-tor-relay